### PR TITLE
Terrible hack to allow simplified destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,11 +11,14 @@ provider "google" {
 
 # Retrieve list of zones to deploy to to prevent needing to know what they are
 # for each region
-data "google_compute_zones" "available" { }
+data "google_compute_zones" "available" {
+  count = var.destroy ? 0 : 1
+  status = "UP"
+ }
 
 # Short name for addressing the list of zones for the region
 locals {
-  zones   = data.google_compute_zones.available.names
+  zones   = try(data.google_compute_zones.available[0].names, ["a","b","c"])
   allowed = concat(["10.128.0.0/9"], var.firewall_allow)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,8 @@ variable "architecture" {
   type        = string
   default     = "xlarge"
 }
+variable "destroy" {
+  description = "Available to facilitate simplified destroy via Puppet Bolt, irrelevant outside specific use case"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
	The project defined for authentication is almost entirely
	irrelevent during a destroy but objects are not fully aware of
	this fact so to make destroying stacks from Puppet Bolt more
	simple this commit facilitates "noop" of things that will fail
	in certain situaiton