### PR TITLE
Removing limition on the number 3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@
 # release of Terraform 0.12
 terraform {
   required_version = ">= 0.12.20"
-  experiments      = [variable_validation]
 }
 
 provider "google" {
@@ -44,7 +43,6 @@ module "loadbalancer" {
   network        = module.networking.network_link
   subnetwork     = module.networking.subnetwork_link
   region         = var.region
-  zones          = local.zones
   instances      = module.instances.compilers
   architecture   = var.architecture
 }

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -19,10 +19,6 @@ variable "id" {
   description = "Randomly generated value used to produce unique names for everything to prevent collisions and visually link resources together"
   type        = string
 }
-variable "zones" {
-  description = "GCP zone that are within the defined GCP region that you wish to use"
-  type        = list(string)
-}
 variable "architecture" {
   description = "Which of the supported PE architectures modules to deploy xlarge, large, or standard"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -20,21 +20,11 @@ variable "compiler_count" {
   description = "The quantity of compilers that are deployed behind a load balancer and will be spread across defined zones"
   type        = number
   default     = 3
-
-  validation {
-    condition     = var.compiler_count >= 3
-    error_message = "The compiler_count variable must be greater or equal to 3."
-  }
 }
 variable "node_count" {
   description = "The quantity of nodes that are deployed within the environment for testing"
   type        = number
   default     = 0
-
-  validation {
-    condition     = length(regexall("^[[:digit:]]+.[[:digit:]]+$", tostring(var.node_count / 3))) == 0
-    error_message = "The node_count variable must be divisible by 3."
-  }
 }
 variable "instance_image" {
   description = "The disk image to use when deploying new cloud instances"


### PR DESCRIPTION
	Commit shifts around how loadbalancers are created to be derived
	from the a list of all available zones to just those zones
	assigned to deployed compiler instances