### PR TITLE
Update to CentOS 8 and ensure correct firewall

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "random_id" "deployment" {
 # make them easier to update
 locals {
   zones          = try(data.google_compute_zones.available[0].names, ["a", "b", "c"])
-  allowed        = concat(["10.128.0.0/9"], var.firewall_allow)
+  allowed        = concat(["10.128.0.0/9", "35.191.0.0/16", "130.211.0.0/22"], var.firewall_allow)
   compiler_count = data.hiera5_bool.has_compilers.value ? var.compiler_count : 0
   id             = random_id.deployment.hex
   network        = module.networking.network_link

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "node_count" {
 variable "instance_image" {
   description = "The disk image to use when deploying new cloud instances"
   type        = string
-  default     = "centos-cloud/centos-7"
+  default     = "centos-cloud/centos-8"
 }
 variable "firewall_allow" {
   description = "List of permitted IP subnets, list most include the internal network and single addresses must be passed as a /32"


### PR DESCRIPTION
Commit will just set CentOS 8 as default cloud image and ensure
firewall is configured to properly to allow health check to succeed