### PR TITLE
(SOLARCH-468) added sensitive boolean for teraform 0.14 and above compatability

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,4 +7,5 @@ output "console" {
 output "pool" {
   value       = module.loadbalancer.lb_dns_name
   description = "The GCP internal network FQDN of the Puppet Enterprise compiler pool"
+  sensitive   = true
 }


### PR DESCRIPTION
module.loadbalancer.lb_dns_name is considered sensitive in gcp but not aws as of 0.14 sensititve = true is required https://www.terraform.io/upgrade-guides/0-14.html#sensitive-values-in-plan-output

or we get an error like

Failed on localhost:
Error: Output refers to sensitive values
on outputs.tf line 7:
 7: output "pool" {
To reduce the risk of accidentally exporting sensitive data that was intended
 to be only internal, Terraform requires that any root module output
 containing sensitive data be explicitly marked as sensitive, to confirm your
 intent.
If you do intend to export this data, annotate the output value as sensitive
 by adding the following argument:
 sensitive = true
 Failed on 1 target: localhost
 

terraform-google-pe_arch/outputs.tf7:10