### PR TITLE
[SOLARCH-525] removes the remote-exec -> connection block from instances template

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -33,18 +33,6 @@ resource "google_compute_instance" "server" {
     subnetwork = var.subnetwork
     access_config {}
   }
-
-  # Using remote-execs on each instance deployment to ensure things are really
-  # really up before doing to the next step, helps with Bolt plans that'll
-  # immediately connect then fail
-  provisioner "remote-exec" {
-    connection {
-      host = self.network_interface[0].access_config[0].nat_ip
-      type = "ssh"
-      user = var.user
-    }
-    inline = ["# Connected"]
-  }
 }
 
 # Reasons given for what is happening in each reason block are they same as
@@ -83,15 +71,6 @@ resource "google_compute_instance" "psql" {
     subnetwork = var.subnetwork
     access_config {}
   }
-
-  provisioner "remote-exec" {
-    connection {
-      host = self.network_interface[0].access_config[0].nat_ip
-      type = "ssh"
-      user = var.user
-    }
-    inline = ["# Connected"]
-  }
 }
 
 # Instances to run as compilers
@@ -126,15 +105,6 @@ resource "google_compute_instance" "compiler" {
     subnetwork = var.subnetwork
     access_config {}
   }
-
-  provisioner "remote-exec" {
-    connection {
-      host = self.network_interface[0].access_config[0].nat_ip
-      type = "ssh"
-      user = var.user
-    }
-    inline = ["# Connected"]
-  }
 }
 
 resource "google_compute_instance" "node" {
@@ -167,14 +137,5 @@ resource "google_compute_instance" "node" {
     network    = var.network
     subnetwork = var.subnetwork
     access_config {}
-  }
-
-  provisioner "remote-exec" {
-    connection {
-      host = self.network_interface[0].access_config[0].nat_ip
-      type = "ssh"
-      user = var.user
-    }
-    inline = ["# Connected"]
   }
 }


### PR DESCRIPTION
### Removing remote-exec calls from the Terraform template

We used to have these `remote-exec` blocks as a method to wait until the recently created instances were available.

The plan is to get rid of these calls in Terraform and rely on the Bolt plan (in [autope](https://github.com/puppetlabs/puppetlabs-autope/pull/45)) to ping these instances to check if they are ready.