### PR TITLE
(feat) Add the ability to specify labels for all instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ locals {
   network        = module.networking.network_link
   subnetwork     = module.networking.subnetwork_link
   has_lb         = data.hiera5_bool.has_compilers.value ? true : false
+  labels         = merge(var.labels, { "stack" = var.stack_name })
 }
 
 # Contain all the networking configuration in a module for readability
@@ -99,7 +100,7 @@ module "instances" {
   compiler_count = local.compiler_count
   node_count     = var.node_count
   instance_image = var.instance_image
-  stack_name     = var.stack_name
+  labels         = local.labels
   project        = var.project
   server_count   = data.hiera5.server_count.value
   database_count = data.hiera5.database_count.value

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -14,9 +14,7 @@ resource "google_compute_instance" "server" {
     "internalDNS"  = "pe-server-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
   }
 
-  labels = {
-    "stack" = var.stack_name
-  }
+  labels = var.labels
 
   boot_disk {
     initialize_params {
@@ -54,9 +52,7 @@ resource "google_compute_instance" "psql" {
     "internalDNS"  = "pe-psql-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
   }
 
-  labels = {
-    "stack" = var.stack_name
-  }
+  labels = var.labels
 
   boot_disk {
     initialize_params {
@@ -88,9 +84,7 @@ resource "google_compute_instance" "compiler" {
     "internalDNS"  = "pe-compiler-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
   }
 
-  labels = {
-    "stack" = var.stack_name
-  }
+  labels = var.labels
 
   boot_disk {
     initialize_params {
@@ -121,9 +115,7 @@ resource "google_compute_instance" "node" {
     "internalDNS"  = "pe-node-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
   }
 
-  labels = {
-    "stack" = var.stack_name
-  }
+  labels = var.labels
 
   boot_disk {
     initialize_params {

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -35,9 +35,9 @@ variable "instance_image" {
   description = "The disk image to use when deploying new cloud instances"
   type        = string
 }
-variable "stack_name" {
-  description = "A name that'll help the user identify which instances are are part of a specific PE deployment"
-  type        = string
+variable "labels" {
+  description = "A map of labels to apply to the instances"
+  type        = map
 }
 variable "project" {
   description = "Name of GCP project that will be used for housing require infrastructure"

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "project" {
   description = "Name of GCP project that will be used for housing require infrastructure"
   type        = string
 }
-variable "user" { 
+variable "user" {
   description = "Instance user name that will used for SSH operations"
   type        = string
 }
@@ -60,4 +60,9 @@ variable "destroy" {
   description = "Available to facilitate simplified destroy via Puppet Bolt, irrelevant outside specific use case"
   type        = bool
   default     = false
+}
+variable "labels" {
+  description = "A map of labels that will be applied to the instances"
+  type        = map
+  default     = {}
 }


### PR DESCRIPTION
Prior to this PR, only the stack id was a label. This
PR adds the ability to pass in additional labels.

A new `labels` variable has been added to specify additional labels without breaking the `stack_name` functionality.