### PR TITLE
Multi variable network decision making

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,8 @@ locals {
   id             = random_id.deployment.hex
   network        = coalesce(module.networking.network_link, try(data.google_compute_subnetwork.existing[0].network, null))
   subnetwork     = coalesce(module.networking.subnetwork_link, try(data.google_compute_subnetwork.existing[0].self_link, null))
-  create_network = var.subnetwork_project == null ? true : false
-  fetch_existing = var.subnetwork_project == null ? 0 : 1 
+  create_network = try(coalesce(var.network, var.subnetwork, var.subnetwork_project), null) == null ? true : false
+  fetch_existing = try(coalesce(var.network, var.subnetwork, var.subnetwork_project), null) == null ? 0 : 1
   has_lb         = data.hiera5_bool.has_compilers.value ? true : false
   labels         = merge(var.labels, { "stack" = var.stack_name })
 }

--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,8 @@ locals {
   id             = random_id.deployment.hex
   network        = coalesce(module.networking.network_link, try(data.google_compute_subnetwork.existing[0].network, null))
   subnetwork     = coalesce(module.networking.subnetwork_link, try(data.google_compute_subnetwork.existing[0].self_link, null))
-  create_network = try(coalesce(var.network, var.subnetwork, var.subnetwork_project), null) == null ? true : false
-  fetch_existing = try(coalesce(var.network, var.subnetwork, var.subnetwork_project), null) == null ? 0 : 1
+  create_network = try(coalesce(var.subnetwork, var.subnetwork_project), null) == null ? true : false
+  fetch_existing = try(coalesce(var.subnetwork, var.subnetwork_project), null) == null ? 0 : 1
   has_lb         = data.hiera5_bool.has_compilers.value ? true : false
   labels         = merge(var.labels, { "stack" = var.stack_name })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -76,11 +76,6 @@ variable "labels" {
   type        = map
   default     = {}
 }
-variable "network" {
-  description = "An optional network to use"
-  type        = string
-  default     = null
-}
 variable "subnetwork" {
   description = "An optional subnetwork to use"
   type        = string


### PR DESCRIPTION
Decide on if plan will attach to an existing network or create new
based on if any of three variable are not null. Makes interface more
intuitive when attaching to existing network within the current project
and more portable between other cloud modules