### PR TITLE
Switch default from CentOS 8 to AlmaLinux 8

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "node_count" {
 variable "instance_image" {
   description = "The disk image to use when deploying new cloud instances"
   type        = string
-  default     = "centos-cloud/centos-8"
+  default     = "almalinux-cloud/almalinux-8"
 }
 variable "stack_name" {
   description = "A name that'll help the user identify which instances are are part of a specific PE deployment"


### PR DESCRIPTION
CentOS 8 has gone away and we've decided to migrate to Alma as our
default for provisioning infrastructure meant for PE installation