### PR TITLE
Provide capability to use custom dns

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,7 @@ module "instances" {
   labels             = var.labels
   metadata           = var.metadata
   project            = var.project
+  domain_name        = var.domain_name
   server_count       = data.hiera5.server_count.value
   database_count     = data.hiera5.database_count.value
   compiler_type      = data.hiera5.compiler_type.value

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -16,7 +16,7 @@ resource "google_compute_instance" "server" {
   # metadata so it is a property of the instance, making it easy to use later in
   # Bolt
   metadata = merge({
-    "internalDNS"  = "pe-server-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
+    "internalDNS"  = var.domain_name == null ? "pe-server-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal" : "pe-server-${var.id}-${count.index}.${var.domain_name}"
   }, local.metadata)
 
   labels = var.labels
@@ -57,7 +57,7 @@ resource "google_compute_instance" "psql" {
   zone  = element(var.zones, count.index)
 
   metadata = merge({
-    "internalDNS"  = "pe-psql-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
+    "internalDNS"  = var.domain_name == null ? "pe-psql-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal" : "pe-psql-${var.id}-${count.index}.${var.domain_name}"
   }, local.metadata)
 
   labels = var.labels
@@ -92,7 +92,7 @@ resource "google_compute_instance" "compiler" {
   zone  = element(var.zones, count.index)
 
   metadata = merge({
-    "internalDNS"  = "pe-compiler-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
+    "internalDNS"  = var.domain_name == null ? "pe-compiler-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal" : "pe-compiler-${var.id}-${count.index}.${var.domain_name}"
   }, local.metadata)
 
   labels = var.labels
@@ -126,7 +126,7 @@ resource "google_compute_instance" "node" {
   zone  = element(var.zones, count.index)
 
   metadata = merge({
-    "internalDNS"  = "pe-compiler-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal"
+    "internalDNS"  = var.domain_name == null ? "pe-node-${var.id}-${count.index}.${element(var.zones, count.index)}.c.${var.project}.internal" : "pe-node-${var.id}-${count.index}.${var.domain_name}"
   }, local.metadata)
 
   labels = var.labels

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -89,3 +89,8 @@ variable "database_disk" {
   description = "Instance disk size of PuppetDB database and replica"
   type        = string
 }
+variable "domain_name" {
+  description = "Custom domain to use for internalDNS"
+  type        = string
+  default     = null
+}

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,6 +1,6 @@
 # Output data that will be used by other submodules to build other parts of the
 # stack to support defined architecture
 output "lb_dns_name" {
-  value       = var.has_lb ? try(google_compute_forwarding_rule.pe_compiler_lb[0].service_name, ""): tolist(var.instances)[0].metadata["internalDNS"]
+  value       = var.has_lb ? try(google_compute_forwarding_rule.pe_compiler_lb[0].service_name, google_compute_forwarding_rule.pe_compiler_lb[0].ip_address): tolist(var.instances)[0].metadata["internalDNS"]
   description = "The DNS name of either the load balancer fronting the compiler pool or the primary master, depending on architecture"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,8 @@ variable "disable_lb" {
   type        = bool
   default     = false
 }
+variable "domain_name" {
+  description = "Custom domain to use for internalDNS"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Provides parameter that can be set to a custom domain for provisioned
instances. Ensures IP address is returned as load balancer address is
the absence of a FQDN.